### PR TITLE
reflactor: update Go module path to CoHDI

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,7 +9,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: composable-resource-operator
-repo: github.com/IBM/composable-resource-operator
+repo: github.com/CoHDI/composable-resource-operator
 resources:
 - api:
     crdVersion: v1
@@ -18,7 +18,7 @@ resources:
   domain: hpsys.ibm.ie.com
   group: cro
   kind: ComposabilityRequest
-  path: github.com/IBM/composable-resource-operator/api/v1alpha1
+  path: github.com/CoHDI/composable-resource-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true
@@ -30,6 +30,6 @@ resources:
   domain: hpsys.ibm.ie.com
   group: cro
   kind: ComposableResource
-  path: github.com/IBM/composable-resource-operator/api/v1alpha1
+  path: github.com/CoHDI/composable-resource-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,9 +36,9 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/controller"
-	webhookcrov1alpha1 "github.com/IBM/composable-resource-operator/internal/webhook/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/controller"
+	webhookcrov1alpha1 "github.com/CoHDI/composable-resource-operator/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/composable-resource-operator
+module github.com/CoHDI/composable-resource-operator
 
 go 1.24.0
 

--- a/internal/cdi/client.go
+++ b/internal/cdi/client.go
@@ -19,7 +19,7 @@ package cdi
 import (
 	"errors"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 type DeviceInfo struct {

--- a/internal/cdi/fti/cm/client.go
+++ b/internal/cdi/fti/cm/client.go
@@ -35,10 +35,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/cdi"
-	"github.com/IBM/composable-resource-operator/internal/cdi/fti"
-	fticmapi "github.com/IBM/composable-resource-operator/internal/cdi/fti/cm/api"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi/fti"
+	fticmapi "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/cm/api"
 )
 
 var (

--- a/internal/cdi/fti/fm/client.go
+++ b/internal/cdi/fti/fm/client.go
@@ -36,10 +36,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/cdi"
-	"github.com/IBM/composable-resource-operator/internal/cdi/fti"
-	ftifmapi "github.com/IBM/composable-resource-operator/internal/cdi/fti/fm/api"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi/fti"
+	ftifmapi "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/fm/api"
 )
 
 var (

--- a/internal/cdi/sunfish/client.go
+++ b/internal/cdi/sunfish/client.go
@@ -25,8 +25,8 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/cdi"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
 )
 
 var setupLog = ctrl.Log.WithName("sunfish_client")

--- a/internal/controller/composabilityrequest_controller.go
+++ b/internal/controller/composabilityrequest_controller.go
@@ -37,8 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/utils"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/utils"
 )
 
 const (

--- a/internal/controller/composabilityrequest_controller_test.go
+++ b/internal/controller/composabilityrequest_controller_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 func createComposabilityRequest(

--- a/internal/controller/composableresource_adapter.go
+++ b/internal/controller/composableresource_adapter.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/IBM/composable-resource-operator/internal/cdi"
-	ftiCM "github.com/IBM/composable-resource-operator/internal/cdi/fti/cm"
-	ftiFM "github.com/IBM/composable-resource-operator/internal/cdi/fti/fm"
-	"github.com/IBM/composable-resource-operator/internal/cdi/sunfish"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
+	ftiCM "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/cm"
+	ftiFM "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/fm"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi/sunfish"
 )
 
 type ComposableResourceAdapter struct {

--- a/internal/controller/composableresource_controller.go
+++ b/internal/controller/composableresource_controller.go
@@ -30,10 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/cdi"
-	"github.com/IBM/composable-resource-operator/internal/utils"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
+	"github.com/CoHDI/composable-resource-operator/internal/utils"
 )
 
 // ComposableResourceReconciler reconciles a ComposableResource object

--- a/internal/controller/composableresource_controller_test.go
+++ b/internal/controller/composableresource_controller_test.go
@@ -47,9 +47,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
-	fticmapi "github.com/IBM/composable-resource-operator/internal/cdi/fti/cm/api"
-	ftifmapi "github.com/IBM/composable-resource-operator/internal/cdi/fti/fm/api"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	fticmapi "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/cm/api"
+	ftifmapi "github.com/CoHDI/composable-resource-operator/internal/cdi/fti/fm/api"
 )
 
 func createComposableResource(

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -38,7 +38,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/upstreamsyncer_controller.go
+++ b/internal/controller/upstreamsyncer_controller.go
@@ -27,9 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
-	"github.com/IBM/composable-resource-operator/internal/cdi"
-	"github.com/IBM/composable-resource-operator/internal/utils"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/internal/cdi"
+	"github.com/CoHDI/composable-resource-operator/internal/utils"
 )
 
 var upstreamSyncerLog = ctrl.Log.WithName("upstream_syncer_controller")

--- a/internal/controller/upstreamsyncer_controller_test.go
+++ b/internal/controller/upstreamsyncer_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 	"github.com/agiledragon/gomonkey/v2"
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	machinev1beta1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"

--- a/internal/utils/gpus.go
+++ b/internal/utils/gpus.go
@@ -32,7 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 var gpusLog = ctrl.Log.WithName("utils_gpus")

--- a/internal/utils/nodes.go
+++ b/internal/utils/nodes.go
@@ -27,7 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/IBM/composable-resource-operator/api/v1alpha1"
+	"github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 var nodesLog = ctrl.Log.WithName("utils_nodes")

--- a/internal/webhook/v1alpha1/composabilityrequest_webhook.go
+++ b/internal/webhook/v1alpha1/composabilityrequest_webhook.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 // nolint:unused

--- a/internal/webhook/v1alpha1/composabilityrequest_webhook_test.go
+++ b/internal/webhook/v1alpha1/composabilityrequest_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 )
 
 var (

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -41,7 +41,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	crov1alpha1 "github.com/IBM/composable-resource-operator/api/v1alpha1"
+	crov1alpha1 "github.com/CoHDI/composable-resource-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
Since the address of the code repository has been moved, the Go module path of project needs to be updated.