### PR TITLE
chore: replace OWNERS.md file with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @hase1128 @shogom2 @NekoHK @tmkymst @mgazz

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-  - mgazz
-  - tmkymst
-  - NekoHK


### PR DESCRIPTION
**Summary**
This PR replaces the Kubernetes-style OWNERS.md file with GitHub’s native CODEOWNERS configuration.

**Motivation**
GitHub CODEOWNERS is better integrated with GitHub’s review and approval workflow and allows us to enforce code ownership directly through repository settings.
Using CODEOWNERS simplifies ownership management and aligns the repository with standard GitHub practices.

**Changes**
Added .github/CODEOWNERS with repository-wide ownership rules
Removed the existing OWNERS.md file

**Notes**
- Code ownership is now enforced via GitHub’s CODEOWNERS mechanism
- Reviewer/approver distinction defined in OWNERS.md is no longer used; ownership is handled uniformly by GitHub