### PR TITLE
ci: add sbom workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -4,11 +4,13 @@ on:
   release:
     types: [published]
 permissions:
-  contents: write
+  contents: read
 jobs:
   generate_sbom_action:
     runs-on: ubuntu-latest
     name: Install bom and generate SBOM
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -16,10 +18,29 @@ jobs:
         uses: kubernetes-sigs/release-actions/setup-bom@8af7b2a5596dff526de9db59b2c4b8457e9f52a1 # v0.4.0
       - name: Generate SBOM
         run: |
-          bom generate -o composable-resource-operator_${{github.ref_name}}_sbom.spdx \
-          --dirs=.\
+          bom generate \
+            -o composable-resource-operator_${{github.ref_name}}_sbom.spdx \
+            --dirs=. \
+            --namespace=https://github.com/${{ github.repository }} \
+            --name=composable-resource-operator \
+            --version=${{ github.ref_name }}
+      - name: Generate checksum
+        run: |
+          sha256sum composable-resource-operator_${{github.ref_name}}_sbom.spdx > \
+            composable-resource-operator_${{github.ref_name}}_sbom.spdx.sha256
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.ref_name }}
+          path: |
+            composable-resource-operator_${{github.ref_name}}_sbom.spdx
+            composable-resource-operator_${{github.ref_name}}_sbom.spdx.sha256
+          retention-days: 90
       - name: Upload SBOM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{github.ref_name}} composable-resource-operator_${{github.ref_name}}_sbom.spdx
+          gh release upload "${{github.ref_name}}" \
+            composable-resource-operator_${{github.ref_name}}_sbom.spdx \
+            composable-resource-operator_${{github.ref_name}}_sbom.spdx.sha256 \
+            --clobber

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,25 @@
+name: Generate SBOM
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+permissions:
+  contents: write
+jobs:
+  generate_sbom_action:
+    runs-on: ubuntu-latest
+    name: Install bom and generate SBOM
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install bom
+        uses: kubernetes-sigs/release-actions/setup-bom@8af7b2a5596dff526de9db59b2c4b8457e9f52a1 # v0.4.0
+      - name: Generate SBOM
+        run: |
+          bom generate -o composable-resource-operator_${{github.ref_name}}_sbom.spdx \
+          --dirs=.\
+      - name: Upload SBOM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{github.ref_name}} composable-resource-operator_${{github.ref_name}}_sbom.spdx


### PR DESCRIPTION
Add a GitHub Actions workflow to generate/publish SBOM.
To improve supply-chain security and to keep our CLOscore in a healthy state continuously by automating SBOM generation in CI.
Ported from kubernetes/minikube:
https://github.com/kubernetes/minikube/blob/d5796e6cc57812c49c2a81510a429bef96a4ae65/.github/workflows/sbom.yml