### PR TITLE
fix: update NVIDIA DRA resource name and VM GPU reset handling

### DIFF
--- a/internal/controller/composableresource_controller.go
+++ b/internal/controller/composableresource_controller.go
@@ -277,7 +277,7 @@ func (r *ComposableResourceReconciler) handleAttachingState(ctx context.Context,
 			}
 		}
 		if err := utils.TerminateKubeletPluginPodOnNode(ctx, r.Clientset, resource.Spec.TargetNode); err != nil {
-			composableResourceLog.Error(err, "failed to restart nvidia-dra-driver-gpu-kubelet-plugin", "composableResource", resource.Name)
+			composableResourceLog.Error(err, "failed to restart dra-driver-nvidia-gpu-kubelet-plugin", "composableResource", resource.Name)
 			resource.Status.Error = err.Error()
 			if err := r.Status().Update(ctx, resource); err != nil {
 				return r.requeueOnErr(resource, err, "failed to update composableResource", "composableResource", resource.Name)
@@ -386,7 +386,7 @@ func (r *ComposableResourceReconciler) handleDetachingState(ctx context.Context,
 			}
 		} else {
 			if err := utils.TerminateKubeletPluginPodOnNode(ctx, r.Clientset, resource.Spec.TargetNode); err != nil {
-				return r.requeueOnErr(resource, err, "failed to restart nvidia-dra-driver-gpu-kubelet-plugin", "composableResource", resource.Name)
+				return r.requeueOnErr(resource, err, "failed to restart dra-driver-nvidia-gpu-kubelet-plugin", "composableResource", resource.Name)
 			}
 		}
 

--- a/internal/controller/composableresource_controller.go
+++ b/internal/controller/composableresource_controller.go
@@ -277,7 +277,7 @@ func (r *ComposableResourceReconciler) handleAttachingState(ctx context.Context,
 			}
 		}
 		if err := utils.TerminateKubeletPluginPodOnNode(ctx, r.Clientset, resource.Spec.TargetNode); err != nil {
-			composableResourceLog.Error(err, "failed to restart dra-driver-nvidia-gpu-kubelet-plugin", "composableResource", resource.Name)
+			composableResourceLog.Error(err, "failed to restart DRA kubelet plugin", "composableResource", resource.Name)
 			resource.Status.Error = err.Error()
 			if err := r.Status().Update(ctx, resource); err != nil {
 				return r.requeueOnErr(resource, err, "failed to update composableResource", "composableResource", resource.Name)
@@ -386,7 +386,7 @@ func (r *ComposableResourceReconciler) handleDetachingState(ctx context.Context,
 			}
 		} else {
 			if err := utils.TerminateKubeletPluginPodOnNode(ctx, r.Clientset, resource.Spec.TargetNode); err != nil {
-				return r.requeueOnErr(resource, err, "failed to restart dra-driver-nvidia-gpu-kubelet-plugin", "composableResource", resource.Name)
+				return r.requeueOnErr(resource, err, "failed to restart DRA kubelet plugin", "composableResource", resource.Name)
 			}
 		}
 

--- a/internal/controller/composableresource_controller_test.go
+++ b/internal/controller/composableresource_controller_test.go
@@ -721,7 +721,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 			"composable-resource-operator-system",
 			"openshift-machine-api",
 			"nvidia-gpu-operator",
-			"nvidia-dra-driver-gpu",
+			"dra-driver-nvidia-gpu",
 		}
 		for _, nsName := range namespacesToCreate {
 			ns := &corev1.Namespace{}
@@ -1595,7 +1595,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-						client.InNamespace("nvidia-dra-driver-gpu"),
+						client.InNamespace("dra-driver-nvidia-gpu"),
 						&client.DeleteAllOfOptions{
 							DeleteOptions: client.DeleteOptions{
 								GracePeriodSeconds: ptr.To(int64(0)),
@@ -1603,7 +1603,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 					Expect(k8sClient.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).NotTo(HaveOccurred())
 
@@ -2582,16 +2582,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -2617,7 +2617,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						return composableResourceStatus
 					}(),
 				}),
-				Entry("should wait when nvidia-dra-driver-gpu-kubelet-plugin Daemonset can not be found in cluster", testcase{
+				Entry("should wait when dra-driver-nvidia-gpu-kubelet-plugin Daemonset can not be found in cluster", testcase{
 					tenant_uuid:  "tenant00-uuid-temp-0000-000000000000",
 					cluster_uuid: "cluster0-uuid-temp-0000-000000000001",
 
@@ -2796,16 +2796,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -2918,16 +2918,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 										Annotations: map[string]string{
 											"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339),
 										},
@@ -3043,16 +3043,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 										Annotations: map[string]string{
 											"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339),
 										},
@@ -3178,16 +3178,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 										Annotations: map[string]string{
 											"kubectl.kubernetes.io/restartedAt": "error",
 										},
@@ -3206,7 +3206,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						Expect(k8sClient.Create(ctx, draDaemonset)).NotTo(HaveOccurred())
 
 						// Update DaemonSet status
-						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "nvidia-dra-driver-gpu-kubelet-plugin", Namespace: "nvidia-dra-driver-gpu"}, draDaemonset)).NotTo(HaveOccurred())
+						Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "dra-driver-nvidia-gpu-kubelet-plugin", Namespace: "dra-driver-nvidia-gpu"}, draDaemonset)).NotTo(HaveOccurred())
 						draDaemonset.Status.DesiredNumberScheduled = 1
 						draDaemonset.Status.NumberReady = 1
 						draDaemonset.Status.CurrentNumberScheduled = 1
@@ -3309,16 +3309,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -3502,16 +3502,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -3587,7 +3587,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					},
 				)).NotTo(HaveOccurred())
 				Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-					client.InNamespace("nvidia-dra-driver-gpu"),
+					client.InNamespace("dra-driver-nvidia-gpu"),
 					&client.DeleteAllOfOptions{
 						DeleteOptions: client.DeleteOptions{
 							GracePeriodSeconds: ptr.To(int64(0)),
@@ -3666,7 +3666,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					Expect(k8sClient.DeleteAllOf(ctx, &metal3v1alpha1.BareMetalHost{}, client.InNamespace("openshift-machine-api"))).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace("composable-resource-operator-system"))).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 					cleanAllComposableResources()
 				})
@@ -4281,7 +4281,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-						client.InNamespace("nvidia-dra-driver-gpu"),
+						client.InNamespace("dra-driver-nvidia-gpu"),
 						&client.DeleteAllOfOptions{
 							DeleteOptions: client.DeleteOptions{
 								GracePeriodSeconds: ptr.To(int64(0)),
@@ -4289,7 +4289,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 					Expect(k8sClient.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).NotTo(HaveOccurred())
 
@@ -4625,10 +4625,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -4741,10 +4741,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -4896,10 +4896,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5064,10 +5064,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5224,10 +5224,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5401,10 +5401,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5572,10 +5572,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5760,10 +5760,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draPod := &corev1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+								Namespace: "dra-driver-nvidia-gpu",
 								Labels: map[string]string{
-									"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+									"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -5822,16 +5822,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -6102,7 +6102,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-						client.InNamespace("nvidia-dra-driver-gpu"),
+						client.InNamespace("dra-driver-nvidia-gpu"),
 						&client.DeleteAllOfOptions{
 							DeleteOptions: client.DeleteOptions{
 								GracePeriodSeconds: ptr.To(int64(0)),
@@ -6110,7 +6110,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-gpu-operator"))).NotTo(HaveOccurred())
 
 					Expect(k8sClient.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).NotTo(HaveOccurred())
@@ -6925,16 +6925,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -7097,16 +7097,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -7263,16 +7263,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -7435,16 +7435,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 						draDaemonset := &appsv1.DaemonSet{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-								Namespace: "nvidia-dra-driver-gpu",
+								Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+								Namespace: "dra-driver-nvidia-gpu",
 							},
 							Spec: appsv1.DaemonSetSpec{
 								Selector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 								},
 								Template: corev1.PodTemplateSpec{
 									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+										Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
@@ -7493,7 +7493,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					},
 				)).NotTo(HaveOccurred())
 				Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-					client.InNamespace("nvidia-dra-driver-gpu"),
+					client.InNamespace("dra-driver-nvidia-gpu"),
 					&client.DeleteAllOfOptions{
 						DeleteOptions: client.DeleteOptions{
 							GracePeriodSeconds: ptr.To(int64(0)),
@@ -7572,7 +7572,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					Expect(k8sClient.DeleteAllOf(ctx, &metal3v1alpha1.BareMetalHost{}, client.InNamespace("openshift-machine-api"))).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace("composable-resource-operator-system"))).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 					cleanAllComposableResources()
 				})
@@ -8265,7 +8265,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-						client.InNamespace("nvidia-dra-driver-gpu"),
+						client.InNamespace("dra-driver-nvidia-gpu"),
 						&client.DeleteAllOfOptions{
 							DeleteOptions: client.DeleteOptions{
 								GracePeriodSeconds: ptr.To(int64(0)),
@@ -8273,7 +8273,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 						},
 					)).NotTo(HaveOccurred())
 
-					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 					Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-gpu-operator"))).NotTo(HaveOccurred())
 
 					cleanAllComposableResources()
@@ -9404,7 +9404,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					},
 				)).NotTo(HaveOccurred())
 				Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-					client.InNamespace("nvidia-dra-driver-gpu"),
+					client.InNamespace("dra-driver-nvidia-gpu"),
 					&client.DeleteAllOfOptions{
 						DeleteOptions: client.DeleteOptions{
 							GracePeriodSeconds: ptr.To(int64(0)),
@@ -9412,7 +9412,7 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 					},
 				)).NotTo(HaveOccurred())
 
-				Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+				Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 				Expect(k8sClient.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).NotTo(HaveOccurred())
 
@@ -9533,16 +9533,16 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 					draDaemonset := &appsv1.DaemonSet{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nvidia-dra-driver-gpu-kubelet-plugin",
-							Namespace: "nvidia-dra-driver-gpu",
+							Name:      "dra-driver-nvidia-gpu-kubelet-plugin",
+							Namespace: "dra-driver-nvidia-gpu",
 						},
 						Spec: appsv1.DaemonSetSpec{
 							Selector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+								MatchLabels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 							},
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{"app": "nvidia-dra-driver-gpu-kubelet-plugin"},
+									Labels: map[string]string{"app": "dra-driver-nvidia-gpu-kubelet-plugin"},
 									Annotations: map[string]string{
 										"kubectl.kubernetes.io/restartedAt": time.Now().Format(time.RFC3339),
 									},
@@ -9614,10 +9614,10 @@ var _ = Describe("ComposableResource Controller", Ordered, func() {
 
 					draPod := &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "nvidia-dra-driver-gpu-kubelet-plugin-test",
-							Namespace: "nvidia-dra-driver-gpu",
+							Name:      "dra-driver-nvidia-gpu-kubelet-plugin-test",
+							Namespace: "dra-driver-nvidia-gpu",
 							Labels: map[string]string{
-								"app.kubernetes.io/name": "nvidia-dra-driver-gpu",
+								"app.kubernetes.io/name": "dra-driver-nvidia-gpu",
 							},
 						},
 						Spec: corev1.PodSpec{

--- a/internal/controller/upstreamsyncer_controller_test.go
+++ b/internal/controller/upstreamsyncer_controller_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Upstreamsyncer Controller", Ordered, func() {
 				"composable-resource-operator-system",
 				"openshift-machine-api",
 				"nvidia-gpu-operator",
-				"nvidia-dra-driver-gpu",
+				"dra-driver-nvidia-gpu",
 			}
 			for _, nsName := range namespacesToCreate {
 				ns := &corev1.Namespace{}
@@ -257,7 +257,7 @@ var _ = Describe("Upstreamsyncer Controller", Ordered, func() {
 					},
 				)).NotTo(HaveOccurred())
 				Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{},
-					client.InNamespace("nvidia-dra-driver-gpu"),
+					client.InNamespace("dra-driver-nvidia-gpu"),
 					&client.DeleteAllOfOptions{
 						DeleteOptions: client.DeleteOptions{
 							GracePeriodSeconds: ptr.To(int64(0)),
@@ -266,7 +266,7 @@ var _ = Describe("Upstreamsyncer Controller", Ordered, func() {
 				)).NotTo(HaveOccurred())
 
 				Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("gpu-operator"))).NotTo(HaveOccurred())
-				Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("nvidia-dra-driver-gpu"))).NotTo(HaveOccurred())
+				Expect(k8sClient.DeleteAllOf(ctx, &appsv1.DaemonSet{}, client.InNamespace("dra-driver-nvidia-gpu"))).NotTo(HaveOccurred())
 
 				Expect(k8sClient.DeleteAllOf(ctx, &resourcev1.ResourceSlice{})).NotTo(HaveOccurred())
 

--- a/internal/utils/gpus.go
+++ b/internal/utils/gpus.go
@@ -1023,7 +1023,7 @@ func getNvidiaDriverDaemonsetPod(ctx context.Context, c client.Client, targetNod
 
 func getDRAKubeletPluginPod(ctx context.Context, clientset *kubernetes.Clientset, targetNodeName string) (*corev1.Pod, error) {
 	pods, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=nvidia-dra-driver-gpu"),
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=dra-driver-nvidia-gpu"),
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", targetNodeName),
 	})
 	if err != nil {
@@ -1031,7 +1031,7 @@ func getDRAKubeletPluginPod(ctx context.Context, clientset *kubernetes.Clientset
 	}
 
 	for _, pod := range pods.Items {
-		if strings.HasPrefix(pod.Name, "nvidia-dra-driver-gpu-kubelet-plugin") {
+		if strings.HasPrefix(pod.Name, "dra-driver-nvidia-gpu-kubelet-plugin") {
 			return &pod, nil
 		}
 	}
@@ -1048,12 +1048,12 @@ func TerminateKubeletPluginPodOnNode(ctx context.Context, clientset *kubernetes.
 	}
 
 	if draPod == nil {
-		gpusLog.Info("skip terminate because nvidia-dra-driver-gpu-kubelet-plugin not found")
+		gpusLog.Info("skip terminate because dra-driver-nvidia-gpu-kubelet-plugin not found")
 		return nil
 	}
 
 	if time.Since(draPod.CreationTimestamp.Time) <= 10*time.Second {
-		gpusLog.Info("skip terminate because nvidia-dra-driver-gpu-kubelet-plugin already terminated recently")
+		gpusLog.Info("skip terminate because dra-driver-nvidia-gpu-kubelet-plugin already terminated recently")
 		return nil
 	}
 

--- a/internal/utils/gpus.go
+++ b/internal/utils/gpus.go
@@ -693,8 +693,16 @@ done;
 				gpusLog.Info("GPU is already in draining status, skip the step", "step", "set maintenance mode", "targetNodeName", targetNodeName, "targetGPUUUID", targetGPUUUID)
 			}
 
-			// In RHOCP, no branch change is required based on the number of remaining GPUs.
-			// Detach gpu by running nvidia-smi drain -r directly in nvidia-driver-daemonset Pod.
+			isVM := isVMByCPUInfoInNvidiaDriverPod(ctx, clientset, restConfig, nvidiaPod, targetNodeName)
+			resetMethod := "nvidia-smi drain -r"
+			resetCommand := []string{"/usr/sbin/chroot", nvidiaDriverRoot, "/usr/bin/nvidia-smi", "drain", "-p", targetGPUBusID, "-r"}
+			if isVM {
+				resetMethod = "sysfs remove"
+				busIDForSysfs := strings.ToLower(targetGPUBusID)
+				resetCommand = []string{"/usr/sbin/chroot", nvidiaDriverRoot, "/bin/sh", "-c", fmt.Sprintf("/usr/bin/echo 1 | /usr/bin/tee /sys/bus/pci/devices/%s/remove > /dev/null", busIDForSysfs)}
+			}
+			gpusLog.Info("selected GPU reset method for nvidia-driver-daemonset pod", "targetNodeName", targetNodeName, "targetGPUUUID", targetGPUUUID, "targetGPUBusID", targetGPUBusID, "isVM", isVM, "resetMethod", resetMethod)
+
 			stdOut, stdErr, execErr = execCommandInPod(
 				ctx,
 				clientset,
@@ -702,7 +710,7 @@ done;
 				nvidiaPod.Namespace,
 				nvidiaPod.Name,
 				nvidiaPod.Spec.Containers[0].Name,
-				[]string{"/usr/sbin/chroot", nvidiaDriverRoot, "/usr/bin/nvidia-smi", "drain", "-p", targetGPUBusID, "-r"},
+				resetCommand,
 			)
 			if execErr != nil || stdErr != "" {
 				return fmt.Errorf("detach command 'reset GPU' failed: '%v', stderr: '%s', stdout: '%s'", execErr, stdErr, stdOut)
@@ -1196,6 +1204,26 @@ func getGPUInfoFromCroNodeAgentPod(ctx context.Context, clientset *kubernetes.Cl
 	}
 
 	return gpuInfos, nil
+}
+
+func isVMByCPUInfoInNvidiaDriverPod(ctx context.Context, clientset *kubernetes.Clientset, restConfig *rest.Config, pod *corev1.Pod, targetNodeName string) bool {
+	stdOut, stdErr, execErr := execCommandInPod(
+		ctx,
+		clientset,
+		restConfig,
+		pod.Namespace,
+		pod.Name,
+		pod.Spec.Containers[0].Name,
+		[]string{"/bin/sh", "-c", "if /usr/bin/grep -qi hypervisor /proc/cpuinfo 2>/dev/null; then /usr/bin/echo true; fi"},
+	)
+	if execErr != nil || stdErr != "" {
+		gpusLog.Info("failed to detect virtualization from /proc/cpuinfo in nvidia-driver-daemonset pod, treat as bare metal", "targetNodeName", targetNodeName, "podName", pod.Name, "execErr", execErr, "stderr", stdErr, "stdout", stdOut)
+		return false
+	}
+
+	isVM := strings.TrimSpace(stdOut) == "true"
+	gpusLog.Info("detected virtualization from /proc/cpuinfo in nvidia-driver-daemonset pod", "targetNodeName", targetNodeName, "podName", pod.Name, "isVM", isVM)
+	return isVM
 }
 
 func checkGPUDrainStatus(ctx context.Context, clientset *kubernetes.Clientset, restConfig *rest.Config, pod *corev1.Pod, targetNodeName string, targetGPUBusID string, driverType GPUDriverType) (bool, error) {

--- a/internal/utils/gpus.go
+++ b/internal/utils/gpus.go
@@ -42,7 +42,12 @@ import (
 
 var gpusLog = ctrl.Log.WithName("utils_gpus")
 
-const nvidiaDriverRoot = "/run/nvidia/driver"
+const (
+	nvidiaDriverRoot = "/run/nvidia/driver"
+
+	nvidiaDRADriverName        = "dra-driver-nvidia-gpu"
+	nvidiaDRAKubeletPluginName = nvidiaDRADriverName + "-kubelet-plugin"
+)
 
 type GPUDriverType string
 
@@ -1031,7 +1036,7 @@ func getNvidiaDriverDaemonsetPod(ctx context.Context, c client.Client, targetNod
 
 func getDRAKubeletPluginPod(ctx context.Context, clientset *kubernetes.Clientset, targetNodeName string) (*corev1.Pod, error) {
 	pods, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=dra-driver-nvidia-gpu"),
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/name=%s", nvidiaDRADriverName),
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", targetNodeName),
 	})
 	if err != nil {
@@ -1039,7 +1044,7 @@ func getDRAKubeletPluginPod(ctx context.Context, clientset *kubernetes.Clientset
 	}
 
 	for _, pod := range pods.Items {
-		if strings.HasPrefix(pod.Name, "dra-driver-nvidia-gpu-kubelet-plugin") {
+		if strings.HasPrefix(pod.Name, nvidiaDRAKubeletPluginName) {
 			return &pod, nil
 		}
 	}
@@ -1056,12 +1061,12 @@ func TerminateKubeletPluginPodOnNode(ctx context.Context, clientset *kubernetes.
 	}
 
 	if draPod == nil {
-		gpusLog.Info("skip terminate because dra-driver-nvidia-gpu-kubelet-plugin not found")
+		gpusLog.Info("skip terminate because DRA kubelet plugin pod not found")
 		return nil
 	}
 
 	if time.Since(draPod.CreationTimestamp.Time) <= 10*time.Second {
-		gpusLog.Info("skip terminate because dra-driver-nvidia-gpu-kubelet-plugin already terminated recently")
+		gpusLog.Info("skip terminate because DRA kubelet plugin pod already terminated recently")
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

This PR includes two GPU-related fixes:

- Update the NVIDIA DRA driver resource name from `nvidia-dra-driver-gpu` to `dra-driver-nvidia-gpu`.
- Update the NVIDIA DRA kubelet plugin pod name prefix from `nvidia-dra-driver-gpu-kubelet-plugin` to `dra-driver-nvidia-gpu-kubelet-plugin`.
- Use sysfs `remove` for GPU reset when running with VM container drivers.

## Changes

- Update the DRA kubelet plugin pod lookup logic to use the new NVIDIA DRA label and pod name prefix.
- Update related log messages and controller test expectations.
- Adjust VM container driver GPU reset flow to remove the PCI device through sysfs.